### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "jsxcs": "./bin/jsxcs"
   },
   "dependencies": {
-    "jscs": "~1.5.9",
-    "react-tools": "~0.10.0",
+    "commander": "~2.3.0",
+    "jscs": "~1.7.0",
+    "react-tools": "~0.11.0",
     "vow": "~0.4.3",
     "vow-fs": "~0.3.1",
-    "commander": "~2.2.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Version 1.7.0 of JSCS just came out with the `--esnext` option for ES6
compatibility. When running jsxcs with `--esnext`, I get the following
error:

> jsxcs --esnext path/to/jsx
> error: unknown option `--esnext'

I think this would be fixed by updating the JSCS dependency version.

While I was at it, I updated the versions of the other dependencies that
have newer versions, and sorted the list of dependencies alphabetically.

Fixes #1. Fixes #3.
