### PR TITLE
Fix preset flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,7 @@
  */
 var Checker = require('./checker');
 var configFile = require('jscs/lib/cli-config');
+var preset = require('jscs/lib/options/preset');
 
 var Vow = require('vow');
 var supportsColor = require('supports-color');


### PR DESCRIPTION
Using the preset flags, `--preset` and `-p`, throw the following error on the command line.

This fixes issue #6 
