### PR TITLE
Update jscs to benefit of --esnext option

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "commander": "~2.3.0",
-    "jscs": "~1.7.0",
+    "jscs": "^1.10.0",
     "react-tools": "~0.12.0",
     "vow": "~0.4.3",
     "vow-fs": "~0.3.1",


### PR DESCRIPTION
Also, by using `^` instead of `~`, you make it easier for package following semver (minor should not break existing api/abi)