### PR TITLE
Add more information in README about deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
-# Deprecated/Obsolete
+# :warning: :bangbang: Deprecated/Obsolete :bangbang: :warning:
 
-JSCS now (since v1.8.0) supports changing the esprima (ast parser) to esprima-fb (Facebooks version of esprima that can parse JSX). This makes JSXCS as a standalone tool obsolete. Same functionality (and more) can be achieved with jscs by using the following command. 
+JSCS now (since v1.8.0) supports changing the esprima (ast parser) to esprima-fb (Facebooks version of esprima that can parse JSX). This makes JSXCS as a standalone tool obsolete. Same functionality (and more) can be achieved with jscs by using the following command.
 
     npm install jscs esprima-fb
     jscs --esprima=esprima-fb
+
+or
+
+    jscs --esprima="./node_module/esprima-fb"
+
+or in your .jscsrc
+
+    "esprima": "esprima-fb"
+
+**Also** include the following in your .jscsrc
+
+    "fileExtensions": [".js", ".jsx"]
+
+Read this [gist](https://gist.github.com/hahahana/3d5fa343f850f4c7fdc3) for more detailed instructions and information/background.
 
 # JSXCS
 


### PR DESCRIPTION
When I was googling to find out how to use JSCS with JSX files I landed on the [npm listing](https://www.npmjs.com/package/jsxcs) first. It took me awhile to realize that it was actually deprecated since I didn't see the Github link right away and the README on npm is out of date with the source. Since this is still ranking high on search results and there are still quite a few downloads (862 this past week!) I figured it might be helpful to provide a bit more info to get people up and running using JSCS, which my PR addresses. 

Also, the package should probably be [deprecated](https://docs.npmjs.com/cli/deprecate) and the README updated on the npm listing.

Thanks!!!
